### PR TITLE
Rename package and podspec to align with XM naming conventions.

### DIFF
--- a/XmInappbrowser.podspec
+++ b/XmInappbrowser.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorInappbrowser'
+  s.name = 'XmInappbrowser'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@capacitor/inappbrowser",
-  "version": "1.0.4-headers",
+  "name": "@xm/inappbrowser",
+  "version": "1.0.4",
   "description": "The InAppBrowser Plugin provides a web browser view that allows you to load any web page externally. It behaves as a standard web browser and is useful to load untrusted content without risking your application's security. It offers three different ways to open URLs; in a WebView, in an in-app system browser (Custom Tabs for Android and SFSafariViewController for iOS), and in the device's default browser.",
   "main": "./dist/plugin.cjs",
   "module": "./dist/plugin.mjs",
@@ -21,7 +21,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapacitorInappbrowser.podspec"
+    "XmInappbrowser.podspec"
   ],
   "author": "Outsystems",
   "license": "MIT",


### PR DESCRIPTION
Updated the package name from "@capacitor/inappbrowser" to "@xm/inappbrowser" and adjusted the versioning. Renamed the podspec file to "XmInappbrowser.podspec" to maintain consistency with the new naming structure.